### PR TITLE
use chalk for colors

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,7 @@
 var util = require('util');
 var path = require('path');
 var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
 
 
 var TopcoatGenerator = module.exports = function TopcoatGenerator(args, options, config) {
@@ -23,13 +24,13 @@ TopcoatGenerator.prototype.askFor = function askFor() {
   var welcome =
   '\n     _-----_' +
   '\n    |       |' +
-  '\n    |' + '--(o)--'.red + '|   .--------------------------.' +
-  '\n   `---------´  |    ' + 'Welcome to Yeoman,'.yellow.bold + '    |' +
-  '\n    ' + '( '.yellow + '_' + '´U`'.yellow + '_' + ' )'.yellow + '   |   ' + 'ladies and gentlemen!'.yellow.bold + '  |' +
+  '\n    |' + chalk.red('--(+)--') + '|   .--------------------------.' +
+  '\n   `---------´  |    ' + chalk.yellow.bold('Welcome to Yeoman,') + '    |' +
+  '\n    ' + chalk.yellow('( ') + '_' + chalk.yellow('´U`') + '_' + chalk.yellow(' )') + '   |   ' + chalk.yellow.bold('ladies and gentlemen!') + '  |' +
   '\n    /___A___\\   \'__________________________\'' +
-  '\n     |  ~  |'.yellow +
-  '\n   __' + '\'.___.\''.yellow + '__' +
-  '\n ´   ' + '`  |'.red + '° ' + '´ Y'.red + ' `\n';
+  chalk.yellow('\n     |  ~  |') +
+  '\n   __' + chalk.yellow('\'.___.\'') + '__' +
+  '\n ´   ' + chalk.red('`  |') + '° ' + chalk.red('´ Y') + ' `\n';
 
   console.log(welcome);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.10.2"
+    "yeoman-generator": "~0.10.2",
+    "chalk": "~0.2.1"
   },
   "devDependencies": {
     "mocha": "~1.9.0"


### PR DESCRIPTION
Current master doesn't work for me with yo > 1.0, since colors.js is not included anymore and thus the string prototype is not extended. This pr uses chalk for terminal colors (like newer yeoman versions do), but imho we might just as well get rid of the boilerplate fancyness, whaddyouthink?
